### PR TITLE
Filter the correct url for windows 10 edge

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -3,7 +3,7 @@
 echo 'Trying to get the download-url for the Vagrant box of "Windows 10 with Legacy Microsoft Edge and Internet Explorer 11"'
 
 apiEndpoint="https://developer.microsoft.com/en-us/microsoft-edge/api/tools/vms/"
-url=$(curl -fsSL $apiEndpoint | jq -r '.[].software[] | select(.name == "Vagrant") | .files[].url')
+url=$(curl -fsSL $apiEndpoint | jq -r '.[].software[] | select(.name == "Vagrant") | .files[] | select(.name | contains("MSEdge.Win10")) | .url')
 
 if [ -z $url ]; then
     echo "... failed"


### PR DESCRIPTION
This is a fix for the `jq` filter. It filters the correct url for windows 10 edge. 

The previous filter returns all the vagrant urls of other versions like windows 7 and wrongly downloads windows 7. The existing script does this which is not what is intended:

```bash
./prepare.sh
Trying to get the download-url for the Vagrant box of "Windows 10 with Legacy Microsoft Edge and Internet Explorer 11"
./prepare.sh: line 8: [: too many arguments

Downloading box from https://az792536.vo.msecnd.net/vms/VMBuild_20150916/Vagrant/IE8/IE8.Win7.Vagrant.zip
https://az792536.vo.msecnd.net/vms/VMBuild_20150916/Vagrant/IE9/IE9.Win7.Vagrant.zip
https://az792536.vo.msecnd.net/vms/VMBuild_20150916/Vagrant/IE10/IE10.Win7.Vagrant.zip
https://az792536.vo.msecnd.net/vms/VMBuild_20150916/Vagrant/IE11/IE11.Win7.Vagrant.zip
https://az792536.vo.msecnd.net/vms/VMBuild_20150916/Vagrant/IE11/IE11.Win81.Vagrant.zip
https://az792536.vo.msecnd.net/vms/VMBuild_20190311/Vagrant/MSEdge/MSEdge.Win10.Vagrant.zip:
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
 12 4288M   12  554M    0     0  21.7M      0  0:03:17  0:00:25  0:02:52 21.7M
```